### PR TITLE
Add Django project initialization command and basic configuration

### DIFF
--- a/apps/backend/my_project/.env
+++ b/apps/backend/my_project/.env
@@ -1,0 +1,9 @@
+# PostgreSQL database configuration
+DB_NAME=mydatabase
+DB_USER=mydatabaseuser
+DB_PASSWORD=mypassword
+DB_HOST=localhost
+DB_PORT=5432
+
+# Prisma ORM configuration
+PRISMA_DATABASE_URL=postgresql://mydatabaseuser:mypassword@localhost:5432/mydatabase

--- a/apps/backend/my_project/settings.py
+++ b/apps/backend/my_project/settings.py
@@ -23,11 +23,13 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'my_api',
+    'corsheaders',  # P1f8b
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',  # P8e06
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -109,3 +111,17 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# CORS headers configuration
+CORS_ALLOW_ALL_ORIGINS = True  # P38ff
+
+# REST framework settings for API versioning and JWT authentication
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
+}  # P7db3
+
+# Prisma ORM integration
+PRISMA_DATABASE_URL = os.getenv('PRISMA_DATABASE_URL', 'postgresql://mydatabaseuser:mypassword@localhost:5432/mydatabase')  # Pcc60

--- a/apps/backend/my_project/urls.py
+++ b/apps/backend/my_project/urls.py
@@ -1,7 +1,13 @@
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('my_api.urls')),
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("PRISMA_DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -2,3 +2,6 @@ Django>=3.2,<4.0
 djangorestframework>=3.12,<4.0
 psycopg2>=2.8,<3.0
 gunicorn>=20.0,<21.0
+djangorestframework-jwt
+django-cors-headers
+prisma


### PR DESCRIPTION
Add CORS headers configuration, JWT authentication, API versioning, and Prisma ORM integration to the Django project.

* **CORS Headers Configuration**
  - Add `corsheaders` to `INSTALLED_APPS` in `settings.py`
  - Add `corsheaders.middleware.CorsMiddleware` to `MIDDLEWARE` in `settings.py`
  - Add `CORS_ALLOW_ALL_ORIGINS = True` to `settings.py`

* **JWT Authentication and API Versioning**
  - Add `djangorestframework-jwt` to `requirements.txt`
  - Add `rest_framework_simplejwt.views` for JWT authentication endpoints in `urls.py`
  - Add `api/token/` and `api/token/refresh/` paths for JWT authentication in `urls.py`
  - Add `REST_FRAMEWORK` settings for API versioning and JWT authentication in `settings.py`

* **Prisma ORM Integration**
  - Add `prisma` to `requirements.txt`
  - Add `PRISMA_DATABASE_URL` environment variable for Prisma ORM integration in `settings.py`
  - Add environment variables for PostgreSQL database and Prisma ORM in `.env`
  - Add Prisma schema for PostgreSQL database in `schema.prisma`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/dynamic-tourism-project/pull/1?shareId=aa2f8416-fb1e-4236-ab2b-8db91f8ec898).