### PR TITLE
Add docker-compose configuration for backend, frontend, and services

### DIFF
--- a/apps/backend/.env
+++ b/apps/backend/.env
@@ -1,0 +1,18 @@
+# PostgreSQL database configuration
+DB_NAME=mydatabase
+DB_USER=mydatabaseuser
+DB_PASSWORD=mypassword
+DB_HOST=localhost
+DB_PORT=5432
+
+# Prisma ORM configuration
+PRISMA_DATABASE_URL=postgresql://mydatabaseuser:mypassword@localhost:5432/mydatabase
+
+# JWT settings
+JWT_SECRET_KEY=your_jwt_secret_key
+JWT_ACCESS_TOKEN_LIFETIME=5
+JWT_REFRESH_TOKEN_LIFETIME=30
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,15 @@
+# Use python:3.9 as the base image
+FROM python:3.9
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the backend code and install dependencies
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Expose port 8000
+EXPOSE 8000
+
+# Set the entrypoint to gunicorn
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8000", "my_project.wsgi:application"]

--- a/apps/backend/my_project/settings.py
+++ b/apps/backend/my_project/settings.py
@@ -133,3 +133,14 @@ RATELIMIT_VIEW = 'django_ratelimit.views.ratelimited'  # P0126
 # Secure cookie settings for production
 SESSION_COOKIE_SECURE = True  # P6b76
 CSRF_COOKIE_SECURE = True  # P6b76
+
+# Redis cache configuration
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}/1",
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+        }
+    }
+}

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM cirrusci/flutter:stable
+
+WORKDIR /app
+
+COPY . .
+
+RUN flutter pub get
+RUN flutter build web
+
+COPY build/web /usr/share/nginx/html
+
+EXPOSE 80
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /static/ {
+        alias /usr/share/nginx/html/static/;
+    }
+
+    location /assets/ {
+        alias /usr/share/nginx/html/assets/;
+    }
+
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        internal;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,21 @@ services:
       - .env
     depends_on:
       - db
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+    networks:
+      - app-network
 
   frontend:
     build:
@@ -24,6 +39,20 @@ services:
       - "8080:8080"
     depends_on:
       - backend
+    environment:
+      - API_URL=http://backend:8000
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+    networks:
+      - app-network
 
   db:
     image: postgres:13
@@ -33,6 +62,59 @@ services:
       POSTGRES_DB: mydatabase
       POSTGRES_USER: mydatabaseuser
       POSTGRES_PASSWORD: mypassword
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+    networks:
+      - app-network
+
+  redis:
+    image: redis:latest
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+    networks:
+      - app-network
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./apps/frontend/build/web:/usr/share/nginx/html
+      - ./apps/frontend/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Add `docker-compose.yml` file to configure services for PostgreSQL, Django REST API, Flutter web build with nginx, and Redis caching.

* **Backend Service:**
  - Add environment variables for Redis configuration.
  - Add health check.
  - Add resource limits.
  - Add network configuration.

* **Frontend Service:**
  - Add environment variables.
  - Add health check.
  - Add resource limits.
  - Add network configuration.

* **Database Service:**
  - Add health check.
  - Add resource limits.
  - Add network configuration.

* **Redis Service:**
  - Add Redis service with health check.
  - Add resource limits.
  - Add network configuration.

* **Nginx Service:**
  - Add nginx service with configuration for serving Flutter web build.
  - Add health check.
  - Add resource limits.
  - Add network configuration.

Add `apps/backend/Dockerfile` to create a Dockerfile for the Django backend using `python:3.9` as the base image, copying the backend code, installing dependencies, setting the working directory to `/app`, exposing port 8000, and setting the entrypoint to `gunicorn`.

Add `apps/frontend/Dockerfile` to create a Dockerfile for the Flutter frontend using `cirrusci/flutter:stable` as the base image, copying the frontend code, installing dependencies, building the Flutter web app, copying the build output to `/usr/share/nginx/html`, exposing port 80, and setting the entrypoint to `nginx`.

Add `apps/backend/.env` file to include environment variables for PostgreSQL, Prisma ORM, JWT settings, and Redis configuration.

Modify `apps/backend/my_project/settings.py` to add Redis cache configuration.

Add `apps/frontend/nginx.conf` to create an Nginx configuration file for serving the Flutter web build, setting the root directory to `/usr/share/nginx/html`, and configuring Nginx to serve static files and handle routing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/dynamic-tourism-project/pull/6?shareId=398c468c-d8fd-4fad-a3a6-25470d00f472).