### PR TITLE
Add Prisma ORM integration

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install Prisma CLI
+RUN npm install -g prisma
+
 # Expose port 8000
 EXPOSE 8000
 

--- a/apps/backend/my_project/settings.py
+++ b/apps/backend/my_project/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     'my_api',
     'corsheaders',  # P1f8b
     'django_ratelimit',  # P4ac3
+    'prisma',  # Pf101
 ]
 
 MIDDLEWARE = [
@@ -69,6 +70,14 @@ DATABASES = {
         'PASSWORD': os.getenv('DB_PASSWORD', 'mypassword'),
         'HOST': os.getenv('DB_HOST', 'localhost'),
         'PORT': os.getenv('DB_PORT', '5432'),
+    },
+    'prisma': {  # P0e2c
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('PRISMA_DB_NAME', 'mydatabase'),
+        'USER': os.getenv('PRISMA_DB_USER', 'mydatabaseuser'),
+        'PASSWORD': os.getenv('PRISMA_DB_PASSWORD', 'mypassword'),
+        'HOST': os.getenv('PRISMA_DB_HOST', 'localhost'),
+        'PORT': os.getenv('PRISMA_DB_PORT', '5432'),
     }
 }
 

--- a/apps/backend/my_project/urls.py
+++ b/apps/backend/my_project/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('api/', include('my_api.urls')),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('prisma/', include('prisma.urls')),
 ]

--- a/apps/backend/my_project/wsgi.py
+++ b/apps/backend/my_project/wsgi.py
@@ -2,6 +2,7 @@ import os
 from django.core.wsgi import get_wsgi_application
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from prisma import Prisma
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'my_project.settings')
 
@@ -12,5 +13,8 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     send_default_pii=True
 )
+
+prisma = Prisma()
+prisma.connect()
 
 application = get_wsgi_application()

--- a/apps/backend/prisma.py
+++ b/apps/backend/prisma.py
@@ -1,0 +1,9 @@
+from prisma import Prisma
+
+prisma = Prisma()
+
+async def connect():
+    await prisma.connect()
+
+async def disconnect():
+    await prisma.disconnect()


### PR DESCRIPTION
Add Prisma ORM integration and configuration to the Django project.

* **Settings Configuration**
  - Add `prisma` to `INSTALLED_APPS` in `settings.py`.
  - Add `DATABASES` configuration for Prisma ORM in `settings.py`.

* **Prisma Integration**
  - Create `prisma.py` for Prisma ORM integration.
  - Add Prisma connection and disconnection in `wsgi.py`.

* **Dockerfile Update**
  - Install Prisma CLI in the Dockerfile.

* **URLs Configuration**
  - Add `prisma` to the URLs in `urls.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/dynamic-tourism-project/pull/13?shareId=d9027818-b05e-4489-b833-1e9feb8939fd).